### PR TITLE
chore: Live reload and endpoint for app restart

### DIFF
--- a/back/sssscs/build.gradle
+++ b/back/sssscs/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'com.sendgrid:sendgrid-java:4.0.1'
 	implementation 'com.twilio.sdk:twilio:9.3.0'
+	compileOnly("org.springframework.boot:spring-boot-devtools")
 }
 
 tasks.named('test') {

--- a/back/sssscs/src/main/java/com/ib/SssscsApplication.java
+++ b/back/sssscs/src/main/java/com/ib/SssscsApplication.java
@@ -3,8 +3,6 @@ package com.ib;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-
-import com.ib.util.twilio.SendgridUtil;
 import org.springframework.context.ConfigurableApplicationContext;
 
 @SpringBootApplication
@@ -16,7 +14,7 @@ public class SssscsApplication {
 		context = SpringApplication.run(SssscsApplication.class, args);
 	}
 
-	//https://www.baeldung.com/java-restart-spring-boot-app#restart-by-creating-a-new-context
+	// https://www.baeldung.com/java-restart-spring-boot-app#restart-by-creating-a-new-context
 	public static void restart() {
 		ApplicationArguments args = context.getBean(ApplicationArguments.class);
 

--- a/back/sssscs/src/main/java/com/ib/SssscsApplication.java
+++ b/back/sssscs/src/main/java/com/ib/SssscsApplication.java
@@ -1,17 +1,31 @@
 package com.ib;
 
+import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 import com.ib.util.twilio.SendgridUtil;
+import org.springframework.context.ConfigurableApplicationContext;
 
 @SpringBootApplication
 public class SssscsApplication {
-	public static void main(String[] args) {
-		SpringApplication.run(SssscsApplication.class, args);
 
-		SendgridUtil sendgridUtil = new SendgridUtil();
-		// sendgridUtil.sendEmail("YOU WIN", "SHDKj=shd==kjsdhs===kJHDKJSDHskjdhskj");
-		// sendgridUtil.sendSMS("sssscs: 432481");
+	private static ConfigurableApplicationContext context;
+
+	public static void main(String[] args) {
+		context = SpringApplication.run(SssscsApplication.class, args);
+	}
+
+	//https://www.baeldung.com/java-restart-spring-boot-app#restart-by-creating-a-new-context
+	public static void restart() {
+		ApplicationArguments args = context.getBean(ApplicationArguments.class);
+
+		Thread thread = new Thread(() -> {
+			context.close();
+			context = SpringApplication.run(SssscsApplication.class, args.getSourceArgs());
+		});
+
+		thread.setDaemon(false);
+		thread.start();
 	}
 }

--- a/back/sssscs/src/main/java/com/ib/util/RestartController.java
+++ b/back/sssscs/src/main/java/com/ib/util/RestartController.java
@@ -1,0 +1,14 @@
+package com.ib.util;
+
+import com.ib.SssscsApplication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class RestartController {
+
+    @PostMapping("/restart")
+    public void restart() {
+        SssscsApplication.restart();
+    }
+}


### PR DESCRIPTION
Note: For live reload to work you must run the server in debug mode. In Eclipse the reload should trigger after file save, in IntelliJ (by default) after Building (Ctrl+F9). Restarting spring through the endpoint is much faster than doing it through the IDE. With these two additions, there should never be a need to restart the server from scratch.