### PR TITLE
13.b session expiration

### DIFF
--- a/back/sssscs/src/main/java/com/ib/config/ControllerAdvisor.java
+++ b/back/sssscs/src/main/java/com/ib/config/ControllerAdvisor.java
@@ -40,10 +40,7 @@ public class ControllerAdvisor {
 		return new ResponseEntity<>(e.getMessage(), HttpStatus.FORBIDDEN);
 	}
 	
-	@ExceptionHandler({ ExpiredJwtException.class })
-	public ResponseEntity<?> handleExpiredJwtException(final ExpiredJwtException e) {
-		return new ResponseEntity<>(e.getMessage(), HttpStatus.UNAUTHORIZED);
-	}
+	// Expired JWT returns 401 directly, see JwtRequestFilter.
 	
 	@ExceptionHandler({ PasswordTooRecentException.class })
 	public ResponseEntity<?> handlePasswordTooRecentException(final PasswordTooRecentException e) {

--- a/back/sssscs/src/main/java/com/ib/config/ControllerAdvisor.java
+++ b/back/sssscs/src/main/java/com/ib/config/ControllerAdvisor.java
@@ -20,7 +20,6 @@ import com.ib.util.validation.BadValidation;
 import com.ib.verification.exception.InvalidCodeException;
 import com.ib.verification.exception.VerificationAttemptPenaltyException;
 
-import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.HttpServletRequest;
 
 @ControllerAdvice
@@ -39,8 +38,6 @@ public class ControllerAdvisor {
 	public ResponseEntity<?> handleWrongPasswordException(final WrongPasswordException e) {
 		return new ResponseEntity<>(e.getMessage(), HttpStatus.FORBIDDEN);
 	}
-	
-	// Expired JWT returns 401 directly, see JwtRequestFilter.
 	
 	@ExceptionHandler({ PasswordTooRecentException.class })
 	public ResponseEntity<?> handlePasswordTooRecentException(final PasswordTooRecentException e) {

--- a/back/sssscs/src/main/java/com/ib/config/ControllerAdvisor.java
+++ b/back/sssscs/src/main/java/com/ib/config/ControllerAdvisor.java
@@ -20,6 +20,7 @@ import com.ib.util.validation.BadValidation;
 import com.ib.verification.exception.InvalidCodeException;
 import com.ib.verification.exception.VerificationAttemptPenaltyException;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.HttpServletRequest;
 
 @ControllerAdvice
@@ -37,6 +38,11 @@ public class ControllerAdvisor {
 	@ExceptionHandler({ WrongPasswordException.class })
 	public ResponseEntity<?> handleWrongPasswordException(final WrongPasswordException e) {
 		return new ResponseEntity<>(e.getMessage(), HttpStatus.FORBIDDEN);
+	}
+	
+	@ExceptionHandler({ ExpiredJwtException.class })
+	public ResponseEntity<?> handleExpiredJwtException(final ExpiredJwtException e) {
+		return new ResponseEntity<>(e.getMessage(), HttpStatus.UNAUTHORIZED);
 	}
 	
 	@ExceptionHandler({ PasswordTooRecentException.class })

--- a/back/sssscs/src/main/java/com/ib/util/security/JwtRequestFilter.java
+++ b/back/sssscs/src/main/java/com/ib/util/security/JwtRequestFilter.java
@@ -72,13 +72,9 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 		return header.substring(header.indexOf("Bearer ") + 7);
 	}
 
-	public UsernamePasswordAuthenticationToken getAuthFromToken(String jwt) {
+	public UsernamePasswordAuthenticationToken getAuthFromToken(String jwt) throws JwtException, IllegalArgumentException, UsernameNotFoundException {
 		UserDetails userDetails;
-		try {
-			userDetails = this.getUserDetailsFromJwtToken(jwt);
-		} catch (JwtException | IllegalArgumentException | UsernameNotFoundException e) {
-			throw e;
-		}
+		userDetails = this.getUserDetailsFromJwtToken(jwt);
 		var authenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null,
 				userDetails.getAuthorities());
 		return authenticationToken;

--- a/back/sssscs/src/main/java/com/ib/util/security/JwtRequestFilter.java
+++ b/back/sssscs/src/main/java/com/ib/util/security/JwtRequestFilter.java
@@ -44,11 +44,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
 		try {
 			String jwtToken = this.getTokenFromRequest(request);
-			var authenticationToken = this.getAuthFromToken(jwtToken);
-			if (authenticationToken == null) {
-				return;
-			}
-			
+			var authenticationToken = this.getAuthFromToken(jwtToken);	
 			jwtTokenUtil.validateToken(jwtToken); // Throws expired token exception
 			SecurityContextHolder.getContext().setAuthentication(authenticationToken);	
 		} catch (ExpiredJwtException e) {
@@ -75,8 +71,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 	public UsernamePasswordAuthenticationToken getAuthFromToken(String jwt) throws JwtException, IllegalArgumentException, UsernameNotFoundException {
 		UserDetails userDetails;
 		userDetails = this.getUserDetailsFromJwtToken(jwt);
-		var authenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null,
-				userDetails.getAuthorities());
+		var authenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 		return authenticationToken;
 	}
 

--- a/back/sssscs/src/main/java/com/ib/util/security/JwtTokenUtil.java
+++ b/back/sssscs/src/main/java/com/ib/util/security/JwtTokenUtil.java
@@ -29,13 +29,9 @@ import io.jsonwebtoken.impl.crypto.MacProvider;
 @Component
 public class JwtTokenUtil {
 	private static final long JWT_LIFE = 10 * 1000;
-//	@Value("verysecret")
-//	private String secret;
-	
     private static final SecretKey secret = MacProvider.generateKey(SignatureAlgorithm.HS256);
     private static final byte[] secretBytes = secret.getEncoded();
     private static final String base64SecretBytes = Base64.getEncoder().encodeToString(secretBytes);
-    
 
 	public String generateToken(String username, Long id, String role) {
 		Map<String, Object> claims = new HashMap<>();
@@ -68,14 +64,12 @@ public class JwtTokenUtil {
 		return Jwts.parser().setSigningKey(base64SecretBytes).parseClaimsJws(token).getBody();
 	}
 	
-	public boolean validateToken(String authToken) {
+	public boolean validateToken(String authToken) throws ExpiredJwtException {
 		try {	
 			Jwts.parser().setSigningKey(base64SecretBytes).parseClaimsJws(authToken);
 			return true;
 		} catch (SignatureException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException ex) {
-			throw new BadCredentialsException("INVALID_CREDENTIALS", ex);
-		} catch (ExpiredJwtException ex) {
-			throw ex;
+			throw new BadCredentialsException("BAD_CREDENTIALS", ex);
 		}
 	}
 }

--- a/back/sssscs/src/main/java/com/ib/util/security/JwtTokenUtil.java
+++ b/back/sssscs/src/main/java/com/ib/util/security/JwtTokenUtil.java
@@ -2,23 +2,40 @@
 
 package com.ib.util.security;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.springframework.beans.factory.annotation.Value;
+import javax.crypto.SecretKey;
+
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Component;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SignatureException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.impl.crypto.MacProvider;
 
 @Component
 public class JwtTokenUtil {
-	private static final long JWT_LIFE = 1080000000;
-	@Value("verysecret")
-	private String secret;
+	private static final long JWT_LIFE = 10 * 1000;
+//	@Value("verysecret")
+//	private String secret;
+	
+    private static final SecretKey secret = MacProvider.generateKey(SignatureAlgorithm.HS256);
+    private static final byte[] secretBytes = secret.getEncoded();
+    private static final String base64SecretBytes = Base64.getEncoder().encodeToString(secretBytes);
+    
 
 	public String generateToken(String username, Long id, String role) {
 		Map<String, Object> claims = new HashMap<>();
@@ -28,8 +45,13 @@ public class JwtTokenUtil {
 	}
 
 	private String doGenerateToken(Map<String, Object> claims, String subject) {
-		return Jwts.builder().setIssuer("sssscs").setClaims(claims).setSubject(subject).setIssuedAt(new Date())
-				.setExpiration(new Date(new Date().getTime() + JWT_LIFE)).signWith(SignatureAlgorithm.HS512, secret)
+		return Jwts.builder()
+				.setIssuer("sssscs")
+				.setClaims(claims)
+				.setSubject(subject)
+				.setIssuedAt(new Date())
+				.setExpiration(new Date(new Date().getTime() + JWT_LIFE))
+				.signWith(SignatureAlgorithm.HS512, base64SecretBytes)
 				.compact();
 	}
 
@@ -43,6 +65,17 @@ public class JwtTokenUtil {
 	}
 
 	private Claims getAllClaimsFromToken(String token) {
-		return Jwts.parser().setSigningKey(secret).parseClaimsJws(token).getBody();
+		return Jwts.parser().setSigningKey(base64SecretBytes).parseClaimsJws(token).getBody();
+	}
+	
+	public boolean validateToken(String authToken) {
+		try {	
+			Jwts.parser().setSigningKey(base64SecretBytes).parseClaimsJws(authToken);
+			return true;
+		} catch (SignatureException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException ex) {
+			throw new BadCredentialsException("INVALID_CREDENTIALS", ex);
+		} catch (ExpiredJwtException ex) {
+			throw ex;
+		}
 	}
 }

--- a/front/sssscs/src/http/HttpService.ts
+++ b/front/sssscs/src/http/HttpService.ts
@@ -1,6 +1,6 @@
 // Axios instance with an interceptor that puts the JWT from localstorage into Authorization: Bearer.
 
-import axios, { InternalAxiosRequestConfig } from "axios";
+import axios, { AxiosResponse, InternalAxiosRequestConfig } from "axios";
 import { Env } from "../common/Environment";
 import { AuthService } from "../auth/AuthService";
 
@@ -17,3 +17,17 @@ axiosInstance.interceptors.request.use(
         return value;
     }
 );
+
+axiosInstance.interceptors.response.use(
+    (response: AxiosResponse<any, any>) => {
+        return response;
+    },
+    (error: any) => {
+        if (error.response.status === 401) {
+            AuthService.removeJWT();      
+            window.location.href = "/login";
+            // Changing GloState?
+        } 
+        return error;
+    }
+)

--- a/front/sssscs/src/http/HttpService.ts
+++ b/front/sssscs/src/http/HttpService.ts
@@ -28,6 +28,6 @@ axiosInstance.interceptors.response.use(
             window.location.href = "/login";
             // Changing GloState?
         } 
-        return error;
+        return Promise.reject(error);
     }
 )

--- a/front/sssscs/src/http/HttpService.ts
+++ b/front/sssscs/src/http/HttpService.ts
@@ -24,10 +24,14 @@ axiosInstance.interceptors.response.use(
     },
     (error: any) => {
         if (error.response.status === 401) {
-            AuthService.removeJWT();      
-            window.location.href = "/login";
-            // Changing GloState?
-        } 
+            logoutAndMoveToLoginPage();
+        }
         return Promise.reject(error);
     }
 )
+
+const logoutAndMoveToLoginPage = () => {
+    AuthService.removeJWT();      
+    window.location.href = "/login";
+    // Changing GloState?
+}


### PR DESCRIPTION
Closes #31 

10 second life cycle. To extend it, change `JWT_LIFE` in `JwtTokenUtil`. When the JWT expires, we have to manually set the response code to 401 (which now always redirects to `/login`) instead of throwing an exception (because the advisor won't catch it).

